### PR TITLE
Add llama.cpp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Promptly is a versatile command-line tool designed to interact with OpenAI's API
 
 ## Features
 
-- **Secure API Token Storage**: Safely store your OpenAI or OpenWebUI API token in the system's Keychain.
+- **Secure API Token Storage**: Safely store your OpenAI (and compatible APIs) or OpenWebUI API token in the system's Keychain.
 - **Flexible API Interaction**: Choose to interact with either OpenAI's API or the OpenWebUI based on your configuration.
 - **Command-line Interface**: Directly pass context strings through the command line to interact with the chosen API.
 
@@ -57,6 +57,8 @@ touch ~/.config/promptly/config.json
 - organizationId: Your organization ID for OpenAI.
 - host (default: api.openai.com): API host address.
 - port (default: 443): API port number.
+- scheme (default: https): API scheme, 'http' or 'https'.
+- usesToken (default: true): Allow an empty token if false.
 - model (default: gpt4_turbo): Model identifier for OpenAI.
 - useOpenWebUI (default: false): Enables OpenWebUI if set to true.
 - openWebUIHost: Host address for OpenWebUI.
@@ -64,6 +66,24 @@ touch ~/.config/promptly/config.json
 - openWebUIModel: Model identifier for OpenWebUI.
 
 ## Usage
+
+### Using llama.cpp via the OpenAI api
+
+Launch the llama server (example without using an API token):
+```bash
+llama-server -hf bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF
+```
+
+Config:
+
+```json
+{
+  "host": "localhost",
+  "port": 8080,
+  "scheme": "http",
+  "usesToken": false
+}
+```
 
 ### Setting Up Your API Token
 

--- a/Sources/Promptly/Promptly.swift
+++ b/Sources/Promptly/Promptly.swift
@@ -12,8 +12,12 @@ struct Promptly: AsyncParsableCommand {
     @Argument(help: "A context string to pass to the system prompt.")
     var contextArgument: String?
 
+    @Argument(help: "Override the default configuration path of ~/.config/promptly/config.json.")
+    var configFile: String = "~/.config/promptly/config.json"
+
     mutating func run() async throws {
-        let prompter = Prompter()
+        let config = try Config.loadConfig(file: configFile)
+        let prompter = Prompter(config: config)
 
         if setupToken {
             try await prompter.setupTokenAction()
@@ -24,8 +28,7 @@ struct Promptly: AsyncParsableCommand {
             throw ValidationError("Usage: promptly <context-string>\\n")
         }
 
-        // Load config; pick which service to call
-        let config = try Config.loadConfig()
+        // Pick which service to call
         if config.useOpenWebUI == true {
             // Use our new Open WebUI endpoint
             try await prompter.runChatOpenWebUIStream(contextArgument: contextArgument)

--- a/Sources/PromptlyKit/Config.swift
+++ b/Sources/PromptlyKit/Config.swift
@@ -4,7 +4,9 @@ public struct Config: Decodable {
     public let organizationId: String?
     public let host: String?
     public let port: Int?
+    public let scheme: String?
     public let model: String?
+    public let usesToken: Bool?
 
     public let useOpenWebUI: Bool?
     public let openWebUIHost: String?
@@ -15,7 +17,9 @@ public struct Config: Decodable {
         organizationId = nil
         host = nil
         port = nil
+        scheme = nil
         model = nil
+        usesToken = nil
 
         useOpenWebUI = false
         openWebUIHost = nil
@@ -23,9 +27,8 @@ public struct Config: Decodable {
         openWebUIModel = nil
     }
 
-    public static func loadConfig() throws -> Config {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        let configURL = homeDir.appendingPathComponent(".config/promptly/config.json")
+    public static func loadConfig(file: String) throws -> Config {
+        let configURL = URL(filePath: NSString(string: file).expandingTildeInPath)
 
         do {
             let data = try Data(contentsOf: configURL)


### PR DESCRIPTION
Adding support for llama.cpp via the OpenAI compatible API.

Requirements for the most basic local llama.cpp usage:
- Supporting llama.cpp without requiring an API token
- Ability to change the API scheme to http

Quality of life improvements:
- Able to set a custom path to the configuration file to easily switch between different servers