### PR TITLE
Refactor configuration and provider handling for multi-API support

### DIFF
--- a/Docs/configuration.md
+++ b/Docs/configuration.md
@@ -9,20 +9,76 @@
 2. Example Configuration
    ```json
    {
-     "scheme": "http",
-     "host": "webui.example.com",
-     "port": 5678,
-     "model": "gpt-3.5-turbo"
+     "model": "o4-mini",
+     "provider": "openai",
+     "providers": {
+       "openai": {
+         "name": "OpenAI",
+         "baseURL": "https://api.openai.com/v1",
+         "envKey": "OPENAI_API_KEY"
+       },
+       "azure": {
+         "name": "AzureOpenAI",
+         "baseURL": "https://YOUR_PROJECT_NAME.openai.azure.com/openai",
+         "envKey": "AZURE_OPENAI_API_KEY"
+       },
+       "openrouter": {
+         "name": "OpenRouter",
+         "baseURL": "https://openrouter.ai/api/v1",
+         "envKey": "OPENROUTER_API_KEY"
+       },
+       "gemini": {
+         "name": "Gemini",
+         "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai",
+         "envKey": "GEMINI_API_KEY"
+       },
+       "ollama": {
+         "name": "Ollama",
+         "baseURL": "http://localhost:11434/v1",
+         "envKey": "OLLAMA_API_KEY"
+       },
+       "mistral": {
+         "name": "Mistral",
+         "baseURL": "https://api.mistral.ai/v1",
+         "envKey": "MISTRAL_API_KEY"
+       },
+       "deepseek": {
+         "name": "DeepSeek",
+         "baseURL": "https://api.deepseek.com",
+         "envKey": "DEEPSEEK_API_KEY"
+       },
+       "xai": {
+         "name": "xAI",
+         "baseURL": "https://api.x.ai/v1",
+         "envKey": "XAI_API_KEY"
+       },
+       "groq": {
+         "name": "Groq",
+         "baseURL": "https://api.groq.com/openai/v1",
+         "envKey": "GROQ_API_KEY"
+       },
+       "arceeai": {
+         "name": "ArceeAI",
+         "baseURL": "https://conductor.arcee.ai/v1",
+         "envKey": "ARCEEAI_API_KEY"
+       }
+     }
    }
    ```
 
 3. Parameter Overview
    - model: Model identifier.
-   - host (default: api.openai.com): API host address.
-   - port (default: 443): API port number.
-   - scheme (default: https): API scheme, 'http' or 'https'.
-   - path (default: v1/chat/completions): completions API path.
-   - organizationId (optional): Your organization ID for OpenAI.
+   - provider: Selected provider key. Must match one of the entries in the `providers` map.
+   - providers: Map of provider configurations. Each entry contains:
+     - name: Human-readable name of the provider.
+     - baseURL: Full base URL for the provider API (may include path prefix). **(If baseURL is specified, other URL components (scheme, host, port, path) should not be used.)**
+     - scheme: URL scheme (e.g., http or https).
+     - host: API host address.
+     - port: API port number.
+     - path: API path prefix (e.g., v1/chat/completions).
+     - envKey: Environment variable name to read the API token from. **(Mutually exclusive with tokenName)**
+     - tokenName: Keychain account name for reading the API token. **(Mutually exclusive with envKey)**
+   - organizationId (optional): Your organization ID for OpenAI-compatible APIs.
    - rawOutput (default: false): When true, the raw response stream is output.
 
 ## Using llama.cpp
@@ -32,45 +88,68 @@ Launch the llama server:
 llama-server -hf bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF
 ```
 
-Config:
+Example config (no token required):
 ```json
 {
-  "host": "localhost",
-  "port": 8080,
-  "scheme": "http"
+  "provider": "llama",
+  "providers": {
+    "llama": {
+      "name": "llama",
+      "scheme": "http",
+      "host": "localhost",
+      "port": 8080,
+      "path": "v1/chat/completions"
+    }
+  }
 }
 ```
 
 ## Using Ollama
 
-Config:
+Example config:
 ```json
 {
-  "model": "qwen2.5-coder:7b",
-  "scheme": "http",
-  "port": 11434,
-  "host": "localhost",
-  "tokenName": "ollama"
+  "provider": "ollama",
+  "providers": {
+    "ollama": {
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1",
+      "tokenName": "ollama"
+    }
+  }
 }
 ```
 
 ## Using OpenAI
 
-Config:
+Example config:
 ```json
 {
+  "provider": "openai",
   "organizationId": "org-123",
   "model": "gpt-4o-mini",
-  "tokenName": "openai"
+  "providers": {
+    "openai": {
+      "name": "OpenAI",
+      "baseURL": "https://api.openai.com/v1",
+      "tokenName": "openai"
+    }
+  }
 }
 ```
 
 ## Using OpenWebUI
 
-Config:
+Example config:
 ```json
 {
-  "path": "api/chat/completions",
-  "tokenName": "openwebui"
+  "provider": "openwebui",
+  "providers": {
+    "openwebui": {
+      "name": "OpenWebUI",
+      "baseURL": "http://localhost:9000/api",
+      "tokenName": "openwebui"
+    }
+  }
 }
 ```

--- a/Sources/PromptlyKit/Config.swift
+++ b/Sources/PromptlyKit/Config.swift
@@ -1,44 +1,40 @@
 import Foundation
 
-public struct Config: Codable {
-    public let host: String
-    public let port: Int
-    public let scheme: String
-    public let path: String
-
+public struct Config: Decodable {
+    /// Model identifier to use for completions.
     public let model: String?
-    public let tokenName: String?
+    /// Organization ID for OpenAI-compatible APIs.
     public let organizationId: String?
+    /// Resolved API endpoint URL.
+    public let chatCompletionsURL: URL
+    /// Resolved API token.
+    public let token: String
 
-    public init(
-        organizationId: String? = nil,
-        host: String = "api.openai.com",
-        port: Int = 443,
-        scheme: String = "https",
-        path: String = "v1/chat/completions",
-        model: String? = nil,
-        tokenName: String? = nil
-    ) {
-        self.organizationId = organizationId
-        self.host = host
-        self.port = port
-        self.scheme = scheme
-        self.path = path
-        self.model = model
-        self.tokenName = tokenName
+    enum CodingKeys: String, CodingKey {
+        case organizationId, model, provider, providers
     }
 
-    public init(from decoder: any Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let providerKey = try container.decode(String.self, forKey: .provider)
+        let specs = try container.decode([String: ProviderSpec].self, forKey: .providers)
+
+        guard let spec = specs[providerKey] else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .provider,
+                in: container,
+                debugDescription: "Invalid provider key '\(providerKey)'"
+            )
+        }
+
         organizationId = try container.decodeIfPresent(String.self, forKey: .organizationId)
-        host = try container.decodeIfPresent(String.self, forKey: .host) ?? "api.openai.com"
-        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? 443
-        scheme = try container.decodeIfPresent(String.self, forKey: .scheme) ?? "https"
-        path = try container.decodeIfPresent(String.self, forKey: .path) ?? "v1/chat/completions"
         model = try container.decodeIfPresent(String.self, forKey: .model)
-        tokenName = try container.decodeIfPresent(String.self, forKey: .tokenName)
+        chatCompletionsURL = try spec.resolveChatCompletionsURL(providerKey: providerKey)
+        token = try spec.resolveToken(providerKey: providerKey)
     }
 
+    /// Load configuration from the given file URL.
     public static func loadConfig(url: URL) throws -> Config {
         let data = try Data(contentsOf: url)
         return try JSONDecoder().decode(Config.self, from: data)

--- a/Sources/PromptlyKit/ConfigError.swift
+++ b/Sources/PromptlyKit/ConfigError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum ConfigError: Error, LocalizedError {
+    case couldNotResolveURL(String)
+    case noKeychainToken(String)
+    case keychainError(String, Error)
+    case noTokenConfiguration(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .couldNotResolveURL(key):
+            return "Could not resolve URL for provider '\(key)'"
+        case let .noKeychainToken(key):
+            return "No keychain token found for provider '\(key)'"
+        case let .keychainError(key, error):
+            return "Unable to fetch keychain token for provider '\(key)': \(error)"
+        case let .noTokenConfiguration(key):
+            return "No token configuration for provider '\(key)'"
+        }
+    }
+}

--- a/Sources/PromptlyKit/ProviderSpec.swift
+++ b/Sources/PromptlyKit/ProviderSpec.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct ProviderSpec: Codable {
+    let name: String
+    let baseURL: String?
+    let scheme: String?
+    let host: String?
+    let port: Int?
+    let path: String?
+    let envKey: String?
+    let tokenName: String?
+
+    func resolveChatCompletionsURL(providerKey: String) throws -> URL {
+        if let base = baseURL, let resolved = URL(string: base) {
+            return resolved.appendingPathComponent("chat/completions")
+        } else if
+            let scheme = scheme,
+            let host = host,
+            let port = port,
+            let resolved = URL(string: "\(scheme)://\(host):\(port)/\(path ?? "v1/chat/completions")") {
+            return resolved
+        } else {
+            throw ConfigError.couldNotResolveURL(providerKey)
+        }
+    }
+
+    func resolveToken(providerKey: String) throws -> String {
+        if
+            let envKey = envKey,
+            let envToken = ProcessInfo.processInfo.environment[envKey] {
+            return envToken
+        } else if let tokenName = tokenName {
+            do {
+                let keychainToken = try Keychain().genericPassword(
+                    account: tokenName,
+                    service: "Promptly"
+                )
+                guard let keychainToken else {
+                    throw ConfigError.noKeychainToken(providerKey)
+                }
+                return keychainToken
+            } catch {
+                throw ConfigError.keychainError(providerKey, error)
+            }
+        } else {
+            throw ConfigError.noTokenConfiguration(providerKey)
+        }
+    }
+}


### PR DESCRIPTION
• Update documentation and example configurations to use a ‘provider’ key with a ‘providers’ map,
  enabling flexible configuration for multiple API providers (e.g., OpenAI, Azure, Ollama, etc.).
• Replace legacy URL components (scheme, host, port, path) with a ProviderSpec that resolves chatCompletionsURL
  and token (from either environment variables or the keychain).
• Update Config+Setup.swift, Config.swift, and Prompter.swift to integrate with the new provider config schema.
• Add ProviderSpec and ConfigError for centralized resolution of API endpoints and error handling.

This change modernizes and generalizes API configuration aligning with approaches used in the AI tool ecosystem, making it easier to add or modify provider settings.

This change breaks backwards compatibility and will require configuration updates.